### PR TITLE
Ensure application.yml is always written

### DIFF
--- a/definitions/custom_env_template.rb
+++ b/definitions/custom_env_template.rb
@@ -13,10 +13,6 @@ define :custom_env_template do
     group params[:deploy][:group]
     mode "0660"
     variables :env => params[:env]
-
-    only_if do
-      File.exists?("#{params[:deploy][:deploy_to]}/shared/config")
-    end
   end
   
 end

--- a/recipes/write_config.rb
+++ b/recipes/write_config.rb
@@ -3,6 +3,16 @@
 
 node[:deploy].each do |application, deploy|
 
+  opsworks_deploy_user do
+    deploy_data deploy
+  end
+
+  opsworks_deploy_dir do
+    user deploy[:user]
+    group deploy[:group]
+    path deploy[:deploy_to]
+  end
+
   custom_env_template do
     application application
     deploy deploy


### PR DESCRIPTION
Rather than conditionally write the application.yml file, include the necessary resources to ensure it is always written.
